### PR TITLE
Add additional basemap layers

### DIFF
--- a/client/src/components/map/constants.ts
+++ b/client/src/components/map/constants.ts
@@ -47,6 +47,16 @@ export const LABELS: Record<LabelsStyle, { name: string }> = {
 export const BASEMAP_LAYERS = {
   "admin-boundaries": { group: "Boundaries", name: "Administrative boundaries" },
   "hydro-boundaries": { group: "Boundaries", name: "Hydrological basins" },
+  "populated-infrastructures": { group: "Infrastructures", name: "Populated infrastructures" },
+  "transportation-network-infrastructures": {
+    group: "Infrastructures",
+    name: "Transportation network",
+  },
+  "water-related-infrastructures": {
+    group: "Infrastructures",
+    name: "Water-related infrastructures",
+  },
+  "hydrographic-data": { group: "Water bodies", name: "Hydrographic data" },
 } as const;
 
 export const DEFAULT_MAP_SETTINGS: {

--- a/client/src/hooks/use-apply-map-settings.ts
+++ b/client/src/hooks/use-apply-map-settings.ts
@@ -12,8 +12,6 @@ export default function useApplyMapSettings(map: MapRef | null) {
   const [labels] = useMapLabels();
   const [basemapLayers] = useMapBasemapLayers();
 
-  console.log(basemapLayers);
-
   useEffect(() => {
     if (map) {
       toggleGroupLayers(map, "basemap-", (group) => group === `basemap-${basemap}`);

--- a/client/src/hooks/use-map-basemap-layers.ts
+++ b/client/src/hooks/use-map-basemap-layers.ts
@@ -5,7 +5,7 @@ import { BASEMAP_LAYERS, DEFAULT_MAP_SETTINGS } from "@/components/map/constants
 export default function useMapBasemapLayers() {
   return useQueryState(
     "basemap-layers",
-    parseAsArrayOf(parseAsStringLiteral(DEFAULT_MAP_SETTINGS.basemapLayers)).withDefault(
+    parseAsArrayOf(parseAsStringLiteral(Object.keys(BASEMAP_LAYERS))).withDefault(
       DEFAULT_MAP_SETTINGS.basemapLayers as (keyof typeof BASEMAP_LAYERS)[],
     ),
   );


### PR DESCRIPTION
Content of the PR:

- Additional basemap layers
  - Waterbodies
    - Hydrographic data
  - Infrastructures
    - Populated infrastructures
    - Transportation network (Roads (row 96))
    - Water-related infrastructures (Waterpoints (row 100) and Waterways (row 101))
- Fix incorrect `useMapBasemapLayers` hook

## Tracking

[SS-62](https://vizzuality.atlassian.net/browse/SS-62)

[SS-62]: https://vizzuality.atlassian.net/browse/SS-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ